### PR TITLE
PARSE-VICON-FILE => MAP-VICON-CSV

### DIFF
--- a/bag-translator.lisp
+++ b/bag-translator.lisp
@@ -22,13 +22,16 @@
 
 (defgeneric to-vicon-object (object)
   (:method ((point marker-point))
-    (make-instance
-     'rst.devices.mocap:vicon/marker-point
-     :name (string-downcase (marker point))
-     :position (make-instance 'rst.math:vec3ddouble
-                              :x (float (field :x point) 1.0d0)
-                              :y (float (field :y point) 1.0d0)
-                              :z (float (field :z point) 1.0d0))))
+    (alexandria:when-let* ((x (field :x point))
+                           (y (field :y point))
+                           (z (field :z point)))
+      (make-instance
+       'rst.devices.mocap:vicon/marker-point
+       :name (string-downcase (marker point))
+       :position (make-instance 'rst.math:vec3ddouble
+                                :x (float x 1.0d0)
+                                :y (float y 1.0d0)
+                                :z (float z 1.0d0)))))
   (:method ((frame frame))
     (make-instance
      'RST.DEVICES.MOCAP:VICON
@@ -37,7 +40,8 @@
      :points (let ((array (make-array (hash-table-count (points frame))
                                       :fill-pointer 0)))
                (loop for point being the hash-values of (points frame)
-                     do (vector-push (to-vicon-object point) array))
+                     for object = (to-vicon-object point)
+                     when object do (vector-push object array))
                array))))
 
 (defun translate-frame (frame channel id)

--- a/bag-translator.lisp
+++ b/bag-translator.lisp
@@ -2,11 +2,10 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *rst-path*
-    (concatenate
-     'string
+    (merge-pathnames
+     #P"rst-proto/proto/stable/"
      (or (sb-posix:getenv "RST")
-         "/home/linus/Projects/Bielefeld/rst")
-     "/rst-proto/proto/stable/"))
+         #P"/home/linus/Projects/Bielefeld/rst/")))
 
   (defun load-proto-file (pathname)
     (let ((pbf:*proto-load-path* (list* *rst-path* pbf:*proto-load-path*)))

--- a/bag-translator.lisp
+++ b/bag-translator.lisp
@@ -64,7 +64,7 @@
           :source-name ,(princ-to-string id)
           :source-config ,(format nil "rsb:/#~A" id))))
 
-(defun translate (vicon-csv-pathname output-pathname)
+(defun translate (vicon-csv-pathnames output-pathname)
   (rsbag:with-bag (bag output-pathname
                        :direction :io
                        :if-exists :supersede
@@ -73,7 +73,8 @@
                                                             (rsb:default-converters)))))
     (let* ((id (uuid:make-v1-uuid))
            (channel (create-vicon-channel bag id)))
-      (map-vicon-csv (lambda (key object)
-                       (case key
-                         (:frame (translate-frame object channel id))))
-                     vicon-csv-pathname))))
+      (dolist (vicon-csv-pathname vicon-csv-pathnames)
+        (map-vicon-csv (lambda (key object)
+                         (case key
+                           (:frame (translate-frame object channel id))))
+                       vicon-csv-pathname)))))

--- a/parser-package.lisp
+++ b/parser-package.lisp
@@ -9,21 +9,19 @@
    #:timestamp
    #:description
    #:resolution
-   #:frames
-   
+
    #:frame
    #:id
    #:sub-id
    #:points
    #:marker-point
    #:markers
-   
+
    #:marker-point
    #:marker
    #:data
    #:metrics
    #:field
    #:field-metric
-   
-   #:parse-field-for-metric
-   #:parse-vicon-file))
+
+   #:map-vicon-csv))

--- a/translator-main.lisp
+++ b/translator-main.lisp
@@ -1,8 +1,7 @@
 (cl:in-package #:vicon-bag-translator)
 
 (defun main ()
-  (destructuring-bind (input &optional (output (make-pathname
-						:type     "tide"
-						:defaults input)))
-      (uiop:command-line-arguments)
-    (convert input output)))
+  (let* ((args   (uiop:command-line-arguments))
+         (inputs (butlast args))
+         (output (alexandria:lastcar args)))
+    (translate inputs output)))

--- a/vicon-parser.lisp
+++ b/vicon-parser.lisp
@@ -154,18 +154,24 @@
   (:method ((metric (eql :m)) field)
     (parse-field-for-metric :float field)))
 
+(defun without-return (string)
+  (when string
+    (remove #\Return string)))
+
 (defun parse-frame (data markers vicon-file)
   (let ((frame (make-instance 'frame
                               :vicon-file vicon-file
                               :id (parse-integer (first data))
                               :sub-id (parse-integer (second data))))
-        (data (cddr data)))
+        (data (cddr data))) ; position data starts after id and sub-id
     (loop for (marker . fields) in markers
           for point = (make-instance 'marker-point :marker marker)
           do (loop for (field . metric) in fields
-                   do (setf (field field point) (parse-field-for-metric metric (pop data))
+                   for value = (pop data)
+                   unless (alexandria:emptyp value)
+                   do (setf (field field point) (parse-field-for-metric metric value)
                             (field-metric field point) metric))
-             (setf (marker-point marker frame) point))
+         (setf (marker-point marker frame) point))
     frame))
 
 (defun parse-frames (data markers vicon-file)


### PR DESCRIPTION
Something like that is necessary to not keep all the Vicon objects in memory. On my laptop, even the 10,000 Vicon frames are too much.
