### PR TITLE
Better binary dumping and support for zipped Vicon textfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: vicon-bag-translator
 
 vicon-bag-translator: vicon-bag-translator.asd *.lisp
-	cl -Q                                                                           \
+	cl                                                                              \
+	  -Q                                                                            \
 	  -S "(:source-registry (:directory \""$$(pwd)"\") :inherit-configuration)"     \
-	  '(asdf:oos (quote asdf:program-op) :vicon-bag-translator)'
+	  -s vicon-bag-translator                                                       \
+	  --dump ! --output $@ -r "vicon-bag-translator:main"
 
 .PHONY: all

--- a/bag-translator.lisp
+++ b/bag-translator.lisp
@@ -135,10 +135,11 @@ If multiple input files are specified, they are
 processed into the bag in sequence on the same
 channel.
 
-Project URL: ~a
-Maintend by: ~a
+Project URL:   ~a
+Maintained by: ~a
 Compiled against
-~{~a~^, ~}"
+  ~@<~{~{~36a ~a~}~^~@:_~}~@:>
+"
             (asdf:component-name system)
             (asdf:component-version system)
             (asdf:system-description system)
@@ -146,7 +147,6 @@ Compiled against
             (asdf:system-maintainer system)
             (mapcar (lambda (dep)
                       (let ((system (asdf:find-system dep)))
-                        (format NIL "~a v~a"
-                                (asdf:component-name system)
-                                (asdf:component-version system))))
+                        (list (asdf:component-name system)
+                              (asdf:component-version system))))
                     (asdf:system-depends-on system)))))

--- a/bag-translator.lisp
+++ b/bag-translator.lisp
@@ -87,19 +87,37 @@
   `(call-with-vicon-channel ,bag-or-pathname (lambda (,id ,channel)
                                                ,@body)))
 
-(defun translate (vicon-file-descriptor channel id)
-  (flet ((process-stream (stream)
-           (let ((file (read-vicon-header stream)))
+(defun translate (vicon-file-descriptor channel id &key file)
+  (flet ((process-stream (stream &key (file nil filep))
+           (let ((file (apply #'read-vicon-header stream
+                              (when filep (list :file file)))))
              (map-read-vicon-frames
               stream file
               (lambda (frame)
                 (translate-frame frame channel id))))))
     (etypecase vicon-file-descriptor
-      ((or pathname string)
-       (with-open-file (stream vicon-file-descriptor :direction :input)
-         (process-stream stream)))
+      (string
+       (translate (parse-namestring vicon-file-descriptor) channel id))
+      (pathname
+       (cond
+         ((wild-pathname-p vicon-file-descriptor)
+          (mapc (alexandria:rcurry #'translate channel id)
+                (directory vicon-file-descriptor)))
+         ((string= (pathname-type vicon-file-descriptor) "zip")
+          (zip:with-zipfile (file vicon-file-descriptor)
+            (translate file channel id)))
+         (t
+          (alexandria:with-input-from-file (stream vicon-file-descriptor)
+            (process-stream stream :file (pathname stream))))))
+      (zip:zipfile
+       (zip:do-zipfile-entries (name entry vicon-file-descriptor)
+         (with-simple-restart (skip "Skip zip-file entry ~A" name)
+           (process-stream (flexi-streams:make-flexi-stream
+                            (flexi-streams:make-in-memory-input-stream
+                             (zip:zipfile-entry-contents entry)))
+                           :file (parse-namestring name)))))
       (stream
-       (process-stream vicon-file-descriptor))
+       (process-stream vicon-file-descriptor :file file))
       (vicon-file
        (loop for frame across (frames vicon-file-descriptor)
              do (translate-frame frame channel id))))))
@@ -130,6 +148,7 @@ vicon-bag-translator output input [input ...]
 
   output        Path to the resulting TIDE file
   input         Path to a Vicon CSV input file
+                (can be a Zip-file containing the CSV file)
 
 If multiple input files are specified, they are
 processed into the bag in sequence on the same

--- a/vicon-parser.asd
+++ b/vicon-parser.asd
@@ -11,4 +11,5 @@
                (:file "vicon-parser"))
   :depends-on (:alexandria
                :cl-ppcre
-               :parse-float))
+               :parse-float
+               :zip))

--- a/vicon-parser.lisp
+++ b/vicon-parser.lisp
@@ -191,7 +191,7 @@
   (alexandria:when-let ((line (read-line stream NIL)))
     (string-trim '(#\Return #\Newline #\Space) line)))
 
-(defun read-vicon-header (stream)
+(defun read-vicon-header (stream &key (file (ignore-errors (pathname stream))))
   (destructuring-bind (description resolution markers fields metrics)
       (loop repeat 5
             for line = (read-clean-line stream)
@@ -199,7 +199,7 @@
             else do (error "Invalid Vicon file: incomplete header."))
     (make-instance
      'vicon-file
-     :file (ignore-errors (pathname stream))
+     :file file
      :description description
      :resolution (parse-integer resolution)
      :markers (parse-marker-list


### PR DESCRIPTION
Turns out Vicon textfiles are actually zipped in the dataset repository. While we unfortunately cannot properly stream data from the zip-file entries, we can at least inflate entries to memory and stream from there.
